### PR TITLE
ajuste na visualização nicho, nível de inglês e data de nascimento

### DIFF
--- a/js/professor/visualizarAlunos.js
+++ b/js/professor/visualizarAlunos.js
@@ -133,7 +133,7 @@ async function filtraUsuarios() {
             </div>
             <div class="form-group">
                 <label for="data-nascimento">Data de Nascimento:</label>
-                <label class="label2" type="date" id="data-nascimento">${aluno.dataNascimento}</label>
+                <label class="label2" type="date" id="data-nascimento">${formatarData(aluno.dataNasc)}</label>
             </div>
             <div class="form-group">
                 <label for="email">E-mail:</label>
@@ -145,11 +145,11 @@ async function filtraUsuarios() {
             </div>
             <div class="form-group">
                 <label for="nivel-ingles">Nível de Inglês:</label>
-                <label class="label2" type="text" id="nivel-ingles">${aluno.nicho.map((nicho) => {return nicho.nicho.nome})}</label>
+                <label class="label2" type="text" id="nivel-ingles">${aluno.nivelIngles.map((nivel) => {return nivel.nivelIngles.nome})}</label>
             </div>
             <div class="form-group">
                 <label for="nicho">Nicho:</label>
-                <label class="label2" type="text" id="nicho">${aluno.nivelIngles.map((nivel) => {return nivel.nivelIngles.nome})}</label>
+                <label class="label2" type="text" id="nicho">${aluno.nicho.map((nicho) => {return nicho.nicho.nome})}</label>
             </div>
         </div>
 


### PR DESCRIPTION
Pequenos ajustes na visualização de aluno 

1. Data de nascimento retornava undefinded, após aplicação de qualquer filtro
2. Valor de nicho e nível inglês eram exibidos invertidos